### PR TITLE
Add global security requirement

### DIFF
--- a/src/main/java/nl/inholland/javajwtstarter/configuration/OpenApiConfig.java
+++ b/src/main/java/nl/inholland/javajwtstarter/configuration/OpenApiConfig.java
@@ -1,17 +1,26 @@
 package nl.inholland.javajwtstarter.configuration;
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.security.*;
+import org.springframework.context.annotation.*;
 
 @Configuration
-@SecurityScheme(
-        name = "bearerAuth",
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT",
-        in = SecuritySchemeIn.HEADER )
 public class OpenApiConfig {
-    // No methods needed — annotation is enough }
+    @Bean
+    public OpenAPI defineOpenApi() {
+        // Security scheme for JWT Bearer token
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", bearerAuth))
+                .addSecurityItem(securityRequirement);
+    }
 }


### PR DESCRIPTION
This PR will fix the issue where JWT is not sent along with the request.

- `@SecurityScheme` annotation will apply to the global configuration
- `@SecurityRequirement` was tried, but this will only apply to the class it is prepended to.
- To make the security requirement work globally, we will need to convert the open api settings to a programmatical solution.